### PR TITLE
Fix for #11

### DIFF
--- a/src/Provider/EntityMutationMetadataProvider.php
+++ b/src/Provider/EntityMutationMetadataProvider.php
@@ -105,11 +105,19 @@ class EntityMutationMetadataProvider
     {
         // check if the PK of the related entity has changed (thus different link)
         if (null !== $left && null !== $right) {
-            $diff = array_diff(
+            $diff = array_udiff(
                 $association_meta->getIdentifierValues($left),
-                $association_meta->getIdentifierValues($right)
-            );
+                $association_meta->getIdentifierValues($right),
+                function ($a, $b) {
+                    // note that equal returns 0, difference should return -1 or 1
+                    if (!is_object($a) && !is_object($b)) {
+                        return (string) $a === (string) $b ? 0 : 1;
+                    }
 
+                    // prevent casting objects to strings
+                    return $a === $b ? 0 : 1;
+                }
+            );
             if (!empty($diff)) {
                 return true;
             }

--- a/test/Provider/EntityMutationMetadataProviderTest.php
+++ b/test/Provider/EntityMutationMetadataProviderTest.php
@@ -136,6 +136,30 @@ class EntityMutationMetadataProviderTest extends \PHPUnit_Framework_TestCase
         $this->assertCount($expected_changes, $provider->getMutatedFields($this->em, $entity, $original));
     }
 
+    /**
+     * @return array[]
+     */
+    public function getMutatedFieldsProvider()
+    {
+        // testing with objects as doctrine allows an @ORM\Id on Foreign Keys
+        $std1 = new \stdClass();
+        $std1->id = 1;
+        $std2 = new \stdClass();
+        $std2->id = 2;
+        $std3 = new \stdClass();
+        $std3->id = 2;
+
+        return [
+            [1, 1, 0],
+            [1, 2, 1],
+            [$std1, $std1, 0],
+            [$std2, $std2, 0],
+            [$std2, $std3, 1],
+            [$std1, $std2, 1],
+            [$std2, $std1, 1]
+        ];
+    }
+
     public function testGetMutatedFieldsEmpty()
     {
         $entity   = new MockEntity();
@@ -150,17 +174,6 @@ class EntityMutationMetadataProviderTest extends \PHPUnit_Framework_TestCase
 
         $provider = new EntityMutationMetadataProvider($this->reader);
         $this->assertEquals(["parent"], $provider->getMutatedFields($this->em, $entity, $original));
-    }
-
-    /**
-     * @return array[]
-     */
-    public function getMutatedFieldsProvider()
-    {
-        return [
-            [1, 1, 0],
-            [1, 2, 1]
-        ];
     }
 
     /**


### PR DESCRIPTION
Error with entity that has a primary and foreign key on the same field. Doctrine allows you to use `@ORM\Id` on a field that has a one-to-one relationship. Because array_diff uses `(string)` to cast the values when diffing, it crashed when an object did not implement `__toString()`.

Fixing with udiff will solve this issue.
