### PR TITLE
Feature/maint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,9 @@ language: php
 
 matrix:
     include:
-        - php: 5.4
-        - php: 5.5
         - php: 5.6
         - php: 7.0
+        - php: 7.1
         - php: hhvm
     allow_failures:
         - php: hhvm

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "psr/log"              : "^1.0.0"
     },
     "require-dev": {
-        "phpunit/phpunit"   : "4.*"
+        "phpunit/phpunit"   : "^5.5.0"
     },
     "minimum-stability": "stable",
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
         "psr/log"              : "^1.0.0"
     },
     "require-dev": {
+        "hostnet/phpcs-tool": "^4.0.8",
         "phpunit/phpunit"   : "^5.5.0"
     },
     "minimum-stability": "stable",

--- a/composer.json
+++ b/composer.json
@@ -3,10 +3,10 @@
     "description": "Provides an event when a Tracked entity changes",
     "license": "MIT",
     "require": {
-        "php"                  : "<8,>=5.4",
-        "doctrine/common"      : "2.*, >=2.4",
-        "doctrine/annotations" : "1.*, >=1.2",
-        "doctrine/orm"         : "2.*, >=2.3",
+        "php"                  : "5.*,>=5.6||7.*",
+        "doctrine/common"      : "2.*,>=2.4.0",
+        "doctrine/annotations" : "1.*,>=1.2.0",
+        "doctrine/orm"         : "2.*,>=2.3.0",
         "psr/log"              : "^1.0.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "php"                  : "5.*,>=5.6||7.*",
         "doctrine/common"      : "2.*,>=2.4.0",
         "doctrine/annotations" : "1.*,>=1.2.0",
-        "doctrine/orm"         : "2.*,>=2.3.0",
+        "doctrine/orm"         : "2.*,>=2.4.0",
         "psr/log"              : "^1.0.0"
     },
     "require-dev": {

--- a/src/Events.php
+++ b/src/Events.php
@@ -6,10 +6,17 @@ namespace Hostnet\Component\EntityTracker;
  */
 final class Events
 {
+    //@codingStandardsIgnoreStart
+    /**
+     * @deprecated use Events::ENTITY_CHANGED instead.
+     */
+    const entityChanged = self::ENTITY_CHANGED;
+    //@codingStandardsIgnoreEnd
+
     /**
      * Thrown when @Tracked (or derived) annotations are found on the entity
      *
      * @var string
      */
-    const entityChanged = 'entityChanged';
+    const ENTITY_CHANGED = 'entityChanged';
 }

--- a/src/Listener/EntityChangedListener.php
+++ b/src/Listener/EntityChangedListener.php
@@ -13,7 +13,7 @@ use Psr\Log\NullLogger;
 /**
  * Listener for entities that use the Tracked Annotation.
  *
- * This listener will fire an "Events::entityChanged" event
+ * This listener will fire an "Events::ENTITY_CHANGED" event
  * per entity that is changed.
  * @author Yannick de Lange <ydelange@hostnet.nl>
  * @author Iltar van der Berg <ivanderberg@hostnet.nl>
@@ -60,7 +60,7 @@ class EntityChangedListener
      *
      * Checks if the entity contains an @Tracked (or derived)
      * annotation. If so, it will attempt to calculate changes
-     * made and dispatch 'Events::entityChanged' with the current
+     * made and dispatch 'Events::ENTITY_CHANGED' with the current
      * and original entity states. Note that the original entity
      * is not managed.
      *
@@ -99,7 +99,7 @@ class EntityChangedListener
                         ]
                     );
                     $em->getEventManager()->dispatchEvent(
-                        Events::entityChanged,
+                        Events::ENTITY_CHANGED,
                         new EntityChangedEvent($em, $entity, $original, $mutated_fields)
                     );
                 }

--- a/test/Event/EntityChangedEventTest.php
+++ b/test/Event/EntityChangedEventTest.php
@@ -10,7 +10,7 @@ class EntityChangedEventTest extends \PHPUnit_Framework_TestCase
 {
     public function testAll()
     {
-        $em              = $this->getMock('Doctrine\ORM\EntityManagerInterface');
+        $em              = $this->createMock('Doctrine\ORM\EntityManagerInterface');
         $current_entity  = new MockEntity();
         $original_entity = new MockEntity();
         $mutated_fields  = ['test'];

--- a/test/Listener/EntityChangedListenerTest.php
+++ b/test/Listener/EntityChangedListenerTest.php
@@ -31,7 +31,7 @@ class EntityChangedListenerTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->logger = $this->getMock('Psr\Log\LoggerInterface');
+        $this->logger = $this->createMock('Psr\Log\LoggerInterface');
 
         $this->em = $this
             ->getMockBuilder('Doctrine\ORM\EntityManager')
@@ -225,7 +225,7 @@ class EntityChangedListenerTest extends \PHPUnit_Framework_TestCase
 
     public function testPreFlushWithProxy()
     {
-        $entity = $this->getMock('Doctrine\ORM\Proxy\Proxy');
+        $entity = $this->createMock('Doctrine\ORM\Proxy\Proxy');
 
         $this->meta_mutation_provider
             ->expects($this->once())
@@ -256,7 +256,7 @@ class EntityChangedListenerTest extends \PHPUnit_Framework_TestCase
         $original     = new \stdClass();
         $original->id = 0;
 
-        $entity = $this->getMock('Doctrine\ORM\Proxy\Proxy');
+        $entity = $this->createMock('Doctrine\ORM\Proxy\Proxy');
         $entity
             ->expects($this->once())
             ->method('__isInitialized')

--- a/test/Provider/EntityAnnotationMetadataProviderTest.php
+++ b/test/Provider/EntityAnnotationMetadataProviderTest.php
@@ -19,7 +19,7 @@ class EntityAnnotationMetadataProviderTest extends \PHPUnit_Framework_TestCase
     {
         $this->reader   = new AnnotationReader();
         $this->provider = new EntityAnnotationMetadataProvider($this->reader);
-        $this->em       = $this->getMock('Doctrine\ORM\EntityManagerInterface');
+        $this->em       = $this->createMock('Doctrine\ORM\EntityManagerInterface');
     }
 
     /**

--- a/test/Provider/EntityMutationMetadataProviderTest.php
+++ b/test/Provider/EntityMutationMetadataProviderTest.php
@@ -19,7 +19,7 @@ class EntityMutationMetadataProviderTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         $this->reader = new AnnotationReader();
-        $this->em     = $this->getMock('Doctrine\ORM\EntityManagerInterface');
+        $this->em     = $this->createMock('Doctrine\ORM\EntityManagerInterface');
         $this->uow    = $this
             ->getMockBuilder('Doctrine\ORM\UnitOfWork')
             ->disableOriginalConstructor()


### PR DESCRIPTION
* drop PHP versions 5.4 and 5.5, those are EOL
* upgrade to phpunit 5
* require doctrine.orm >2.4 since it already is
* fixed codestyle and include phpcs