### PR TITLE
Changed info() logging to debug()

### DIFF
--- a/src/Listener/EntityChangedListener.php
+++ b/src/Listener/EntityChangedListener.php
@@ -97,7 +97,7 @@ class EntityChangedListener
                 $mutated_fields = $this->meta_mutation_provider->getMutatedFields($em, $entity, $original);
 
                 if (!empty($mutated_fields)) {
-                    $this->logger->info(
+                    $this->logger->debug(
                         'Going to notify a change (preFlush) to {entity_class}, which has {mutated_fields}',
                         [
                             'entity_class' => get_class($entity),
@@ -133,7 +133,7 @@ class EntityChangedListener
 
         $mutated_fields = $this->meta_mutation_provider->getMutatedFields($em, $entity, null);
 
-        $this->logger->info(
+        $this->logger->debug(
             'Going to notify a change (prePersist) to {entity_class}, which has {mutated_fields}',
             [
                 'entity_class' => get_class($entity),

--- a/test/Listener/EntityChangedListenerTest.php
+++ b/test/Listener/EntityChangedListenerTest.php
@@ -117,7 +117,7 @@ class EntityChangedListenerTest extends \PHPUnit_Framework_TestCase
             ->getFullChangeSet($this->em->reveal())
             ->willReturn($this->genericEntityDataProvider($entity));
         $this->meta_annotation_provider->isTracked($this->em->reveal(), $entity)->willReturn(true);
-        $this->logger->info(Argument::cetera())->shouldBeCalled();
+        $this->logger->debug(Argument::cetera())->shouldBeCalled();
         $this->meta_mutation_provider->isEntityManaged($this->em->reveal(), $entity)->willReturn(true);
         $this->meta_mutation_provider->createOriginalEntity($this->em->reveal(), $entity)->willReturn($original);
         $this->meta_mutation_provider->getMutatedFields($this->em->reveal(), $entity, $original)->willReturn(['id']);
@@ -171,7 +171,7 @@ class EntityChangedListenerTest extends \PHPUnit_Framework_TestCase
         $this->meta_annotation_provider->isTracked($this->em->reveal(), $entity->reveal())->willReturn(true);
         $this->meta_mutation_provider->isEntityManaged($this->em->reveal(), $entity->reveal())->willReturn(true);
         $entity->__isInitialized()->willReturn(true);
-        $this->logger->info(Argument::cetera())->shouldBeCalled();
+        $this->logger->debug(Argument::cetera())->shouldBeCalled();
         $this->meta_mutation_provider->createOriginalEntity($this->em->reveal(), $entity)->willReturn($original);
         $this->meta_mutation_provider
             ->getMutatedFields($this->em->reveal(), $entity->reveal(), $original)


### PR DESCRIPTION
The things the event listener is logging is really just debug information. To prevent flooding logs that you would be actually interested in, I've changed the log message type `info` to `debug`.
