### PR TITLE
Events for new entities trigger wrong

### DIFF
--- a/src/Listener/EntityChangedListener.php
+++ b/src/Listener/EntityChangedListener.php
@@ -106,4 +106,18 @@ class EntityChangedListener
             }
         }
     }
+
+    /**
+     * Pre Persist event callback
+     *
+     * Checks if the entity contains an @Tracked (or derived)
+     * annotation. If so, it will dispatch 'Events::ENTITY_CHANGED'
+     * with the new entity states.
+     *
+     * @param LifecycleEventArgs $event
+     */
+    public function prePersist(LifecycleEventArgs $event)
+    {
+        // do nothing, will be removed later on.
+    }
 }

--- a/src/Listener/EntityChangedListener.php
+++ b/src/Listener/EntityChangedListener.php
@@ -82,21 +82,15 @@ class EntityChangedListener
             }
 
             foreach ($updates as $entity) {
-                if (!$this->meta_mutation_provider->isEntityManaged($em, $entity)
-                    || ($entity instanceof Proxy && !$entity->__isInitialized())
-                ) {
+                if ($entity instanceof Proxy && !$entity->__isInitialized()) {
                     continue;
                 }
 
                 $original = $this->meta_mutation_provider->createOriginalEntity($em, $entity);
 
-                // New entities are handled in the pre-persist event.
-                if (!$original) {
-                    continue;
-                }
                 $mutated_fields = $this->meta_mutation_provider->getMutatedFields($em, $entity, $original);
 
-                if (!empty($mutated_fields)) {
+                if (null === $original || !empty($mutated_fields)) {
                     $this->logger->debug(
                         'Going to notify a change (preFlush) to {entity_class}, which has {mutated_fields}',
                         [
@@ -111,39 +105,5 @@ class EntityChangedListener
                 }
             }
         }
-    }
-
-    /**
-     * Pre Persist event callback
-     *
-     * Checks if the entity contains an @Tracked (or derived)
-     * annotation. If so, it will dispatch 'Events::ENTITY_CHANGED'
-     * with the new entity states.
-     *
-     * @param LifecycleEventArgs $event
-     */
-    public function prePersist(LifecycleEventArgs $event)
-    {
-        $em     = $event->getEntityManager();
-        $entity = $event->getEntity();
-
-        if (false === $this->meta_annotation_provider->isTracked($em, $entity)) {
-            return;
-        }
-
-        $mutated_fields = $this->meta_mutation_provider->getMutatedFields($em, $entity, null);
-
-        $this->logger->debug(
-            'Going to notify a change (prePersist) to {entity_class}, which has {mutated_fields}',
-            [
-                'entity_class' => get_class($entity),
-                'mutated_fields' => $mutated_fields
-            ]
-        );
-
-        $em->getEventManager()->dispatchEvent(
-            Events::ENTITY_CHANGED,
-            new EntityChangedEvent($em, $entity, null, $mutated_fields)
-        );
     }
 }

--- a/src/Listener/EntityChangedListener.php
+++ b/src/Listener/EntityChangedListener.php
@@ -114,6 +114,8 @@ class EntityChangedListener
      * annotation. If so, it will dispatch 'Events::ENTITY_CHANGED'
      * with the new entity states.
      *
+     * @deprecated Will be removed. Here so the bundle does not break.
+     *
      * @param LifecycleEventArgs $event
      */
     public function prePersist(LifecycleEventArgs $event)

--- a/src/Provider/EntityMutationMetadataProvider.php
+++ b/src/Provider/EntityMutationMetadataProvider.php
@@ -197,7 +197,7 @@ class EntityMutationMetadataProvider
 
             $change_set[$class] = $entities;
             foreach ($entities as $entity) {
-                foreach ($this->checkAssociations($em, $metadata, $entity) as [$metadata_child, $child]) {
+                foreach ($this->checkAssociations($em, $metadata, $entity) as list($metadata_child, $child)) {
                     if (!isset($change_set[$metadata_child->rootEntityName])) {
                         $change_set[$metadata_child->rootEntityName] = [];
                     }
@@ -220,7 +220,7 @@ class EntityMutationMetadataProvider
                 $change_set[$metadata->rootEntityName][] = $entity;
             }
 
-            foreach ($this->checkAssociations($em, $metadata, $entity) as [$metadata_child, $child]) {
+            foreach ($this->checkAssociations($em, $metadata, $entity) as list($metadata_child, $child)) {
                 if (!isset($change_set[$metadata_child->rootEntityName])) {
                     $change_set[$metadata_child->rootEntityName] = [];
                 }

--- a/src/Provider/EntityMutationMetadataProvider.php
+++ b/src/Provider/EntityMutationMetadataProvider.php
@@ -195,7 +195,7 @@ class EntityMutationMetadataProvider
         foreach ($managed as $class => $entities) {
             $metadata = $em->getClassMetadata($class);
 
-            $change_set[$class] = $entities;
+            $change_set[$class] = array_values($entities);
 
             foreach ($entities as $entity) {
                 $this->appendAssociations($em, $metadata, $entity, $change_set);

--- a/test/Functional/Entity/Author.php
+++ b/test/Functional/Entity/Author.php
@@ -1,6 +1,7 @@
 <?php
 namespace Hostnet\Component\EntityTracker\Functional\Entity;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
@@ -44,5 +45,6 @@ class Author
     public function __construct($name)
     {
         $this->name = $name;
+        $this->books = new ArrayCollection();
     }
 }

--- a/test/Functional/Entity/Toolbox.php
+++ b/test/Functional/Entity/Toolbox.php
@@ -44,6 +44,6 @@ class Toolbox
         foreach ($tools as $tool) {
             $tool->toolbox = $this;
         }
-        $this->tools = $tools;
+        $this->tools = new ArrayCollection($tools);
     }
 }

--- a/test/Functional/EventListenerTest.php
+++ b/test/Functional/EventListenerTest.php
@@ -70,6 +70,7 @@ class EventListenerTest extends \PHPUnit_Framework_TestCase
         );
 
         $event_manager->addEventListener('preFlush', $entity_changed_listener);
+        $event_manager->addEventListener('prePersist', $entity_changed_listener);
         $event_manager->addEventListener('entityChanged', $this);
 
         $this->events = [];

--- a/test/Functional/EventListenerTest.php
+++ b/test/Functional/EventListenerTest.php
@@ -136,8 +136,8 @@ class EventListenerTest extends \PHPUnit_Framework_TestCase
         $this->em->flush();
 
         self::assertCount(2, $this->events);
-        self::assertSame($tolkien->books[0], $this->events[0][0]->getCurrentEntity());
-        self::assertSame($tolkien->books[1], $this->events[1][0]->getCurrentEntity());
+        self::assertTrue($tolkien->books->contains($this->events[0][0]->getCurrentEntity()));
+        self::assertTrue($tolkien->books->contains($this->events[1][0]->getCurrentEntity()));
     }
 
     public function testNewBookPersistAuthorEditBook()

--- a/test/Functional/EventListenerTest.php
+++ b/test/Functional/EventListenerTest.php
@@ -116,6 +116,7 @@ class EventListenerTest extends \PHPUnit_Framework_TestCase
         $this->events = [];
 
         $tolkien->books[] = new Book('The Return of the King');
+        $this->em->persist($tolkien);
         $this->em->flush();
 
         self::assertCount(1, $this->events);
@@ -132,6 +133,7 @@ class EventListenerTest extends \PHPUnit_Framework_TestCase
         $tolkien->books[] = new Book('The Hobbit');
         $this->em->persist($tolkien);
         $tolkien->books[] = new Book('The Silmarillion');
+        $this->em->persist($tolkien);
         $this->em->flush();
 
         self::assertCount(2, $this->events);
@@ -207,5 +209,25 @@ class EventListenerTest extends \PHPUnit_Framework_TestCase
             'tag' => 'barbaz',
             'tools' => new ArrayCollection([])
         ], $this->events[0][1]);
+    }
+
+    /**
+     * Test "Persistence by reachability". Reachable entities in collections
+     * are persisted by default if there is a cascade persist.
+     *
+     * The listener should also trigger on those.
+     */
+    public function testReachablePersist()
+    {
+        $tolkien = new Author('J. R. R. Tolkien');
+        $this->em->persist($tolkien);
+        $this->em->flush();
+        $this->events = [];
+
+        // Added book and do not call persist for any entities.
+        $tolkien->books[] = new Book('The Return of the King');
+        $this->em->flush();
+
+        self::assertCount(1, $this->events);
     }
 }

--- a/test/Functional/EventListenerTest.php
+++ b/test/Functional/EventListenerTest.php
@@ -70,7 +70,6 @@ class EventListenerTest extends \PHPUnit_Framework_TestCase
         );
 
         $event_manager->addEventListener('preFlush', $entity_changed_listener);
-        $event_manager->addEventListener('prePersist', $entity_changed_listener);
         $event_manager->addEventListener('entityChanged', $this);
 
         $this->events = [];

--- a/test/Functional/EventListenerTest.php
+++ b/test/Functional/EventListenerTest.php
@@ -6,6 +6,7 @@ use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Tools\SchemaTool;
 use Doctrine\ORM\Tools\Setup;
+use Doctrine\ORM\UnitOfWork;
 use Hostnet\Component\DatabaseTest\MysqlPersistentConnection;
 use Hostnet\Component\EntityTracker\Event\EntityChangedEvent;
 use Hostnet\Component\EntityTracker\Functional\Entity\Author;
@@ -76,7 +77,7 @@ class EventListenerTest extends \PHPUnit_Framework_TestCase
 
     public function entityChanged(EntityChangedEvent $event)
     {
-        $this->events[] = $event;
+        $this->events[] = [$event, (array) $event->getCurrentEntity()];
     }
 
     public function testNewAuthorNewBook()
@@ -88,7 +89,7 @@ class EventListenerTest extends \PHPUnit_Framework_TestCase
         $this->em->flush();
 
         self::assertCount(1, $this->events);
-        self::assertSame($tolkien->books[0], $this->events[0]->getCurrentEntity());
+        self::assertSame($tolkien->books[0], $this->events[0][0]->getCurrentEntity());
     }
 
     public function testNewBookPersistAuthor()
@@ -104,7 +105,7 @@ class EventListenerTest extends \PHPUnit_Framework_TestCase
         $this->em->flush();
 
         self::assertCount(1, $this->events);
-        self::assertSame($tolkien->books[0], $this->events[0]->getCurrentEntity());
+        self::assertSame($tolkien->books[0], $this->events[0][0]->getCurrentEntity());
     }
 
     public function testNewBook()
@@ -118,7 +119,7 @@ class EventListenerTest extends \PHPUnit_Framework_TestCase
         $this->em->flush();
 
         self::assertCount(1, $this->events);
-        self::assertSame($tolkien->books[0], $this->events[0]->getCurrentEntity());
+        self::assertSame($tolkien->books[0], $this->events[0][0]->getCurrentEntity());
     }
 
     public function testNewBookPersistAuthorNewBook()
@@ -134,8 +135,8 @@ class EventListenerTest extends \PHPUnit_Framework_TestCase
         $this->em->flush();
 
         self::assertCount(2, $this->events);
-        self::assertSame($tolkien->books[0], $this->events[0]->getCurrentEntity());
-        self::assertSame($tolkien->books[1], $this->events[1]->getCurrentEntity());
+        self::assertSame($tolkien->books[0], $this->events[0][0]->getCurrentEntity());
+        self::assertSame($tolkien->books[1], $this->events[1][0]->getCurrentEntity());
     }
 
     public function testNewBookPersistAuthorEditBook()
@@ -150,8 +151,8 @@ class EventListenerTest extends \PHPUnit_Framework_TestCase
         $this->em->flush();
 
         self::assertCount(1, $this->events);
-        self::assertSame('The Silmarillion', $this->events[0]->getCurrentEntity()->title);
-        self::assertSame('Silmarillion', $this->events[0]->getOriginalEntity()->title);
+        self::assertSame('The Silmarillion', $this->events[0][0]->getCurrentEntity()->title);
+        self::assertSame('Silmarillion', $this->events[0][0]->getOriginalEntity()->title);
     }
 
     public function testMutatedAssociations()
@@ -161,7 +162,7 @@ class EventListenerTest extends \PHPUnit_Framework_TestCase
         $this->em->persist($toolbox);
         $this->em->flush();
 
-        self::assertSame(['id', 'tag'], $this->events[0]->getMutatedFields());
+        self::assertSame(['id', 'tag'], $this->events[0][0]->getMutatedFields());
 
         // Add new Tool to the Toolbox.
         $this->events     = [];
@@ -169,12 +170,42 @@ class EventListenerTest extends \PHPUnit_Framework_TestCase
 
         $toolbox->tag = "Work don't play";
         $this->em->flush();
-        self::assertSame(['tag'], $this->events[0]->getMutatedFields());
+        self::assertSame(['tag'], $this->events[0][0]->getMutatedFields());
 
         // Remove a Tool from the Toolbox.
         $this->events = [];
         unset($toolbox->tools[2]->toolbox, $toolbox->tools[2]);
 
         $this->em->flush();
+    }
+
+    public function testPersistDetach()
+    {
+        $toolbox = new Toolbox();
+        $this->em->persist($toolbox);
+        $this->em->detach($toolbox);
+        $this->em->flush();
+
+        self::assertEmpty($this->events);
+        self::assertEquals(UnitOfWork::STATE_NEW, $this->em->getUnitOfWork()->getEntityState($toolbox));
+    }
+
+    public function testCorrectValues()
+    {
+        $toolbox = new Toolbox();
+        $toolbox->tag = 'foobar';
+
+        $this->em->persist($toolbox);
+
+        $toolbox->tag = 'barbaz';
+
+        $this->em->flush();
+
+        self::assertSame(['id', 'tag'], $this->events[0][0]->getMutatedFields());
+        self::assertSame([
+            'id' => null,
+            'tag' => 'barbaz',
+            'tools' => []
+        ], $this->events[0][1]);
     }
 }

--- a/test/Functional/EventListenerTest.php
+++ b/test/Functional/EventListenerTest.php
@@ -2,6 +2,7 @@
 namespace Hostnet\Component\EntityTracker\Functional;
 
 use Doctrine\Common\Annotations\AnnotationReader;
+use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Tools\SchemaTool;
@@ -202,10 +203,10 @@ class EventListenerTest extends \PHPUnit_Framework_TestCase
         $this->em->flush();
 
         self::assertSame(['id', 'tag'], $this->events[0][0]->getMutatedFields());
-        self::assertSame([
+        self::assertEquals([
             'id' => null,
             'tag' => 'barbaz',
-            'tools' => []
+            'tools' => new ArrayCollection([])
         ], $this->events[0][1]);
     }
 }

--- a/test/Listener/EntityChangedListenerTest.php
+++ b/test/Listener/EntityChangedListenerTest.php
@@ -193,6 +193,11 @@ class EntityChangedListenerTest extends \PHPUnit_Framework_TestCase
         $this->listener->preFlush(new PreFlushEventArgs($this->em->reveal()));
     }
 
+    public function testPrePersist()
+    {
+        $this->listener->prePersist(new LifecycleEventArgs(new \stdClass(), $this->em->reveal()));
+    }
+
     /**
      * @param  mixed $entity
      * @return array[]

--- a/test/Listener/EntityChangedListenerTest.php
+++ b/test/Listener/EntityChangedListenerTest.php
@@ -18,21 +18,22 @@ use Psr\Log\LoggerInterface;
  *
  * @author Yannick de Lange <ydelange@hostnet.nl>
  * @author Iltar van der Berg <ivanderberg@hostnet.nl>
- * @covers Hostnet\Component\EntityTracker\Listener\EntityChangedListener
+ * @covers \Hostnet\Component\EntityTracker\Listener\EntityChangedListener
  */
 class EntityChangedListenerTest extends \PHPUnit_Framework_TestCase
 {
     private $meta_annotation_provider;
     private $meta_mutation_provider;
-    private $listener;
     private $event_manager;
     private $em;
     private $logger;
     private $event;
 
     /**
-     * {@inheritdoc}
+     * @var EntityChangedListener
      */
+    private $listener;
+
     protected function setUp()
     {
         $this->meta_annotation_provider = $this->prophesize(EntityAnnotationMetadataProvider::class);
@@ -84,6 +85,7 @@ class EntityChangedListenerTest extends \PHPUnit_Framework_TestCase
             ->shouldNotBeCalled();
         $this->meta_annotation_provider->isTracked($this->em->reveal(), $entity)->willReturn(true);
         $this->meta_mutation_provider->isEntityManaged($this->em->reveal(), $entity)->willReturn(false);
+
         $this->listener->preFlush(new PreFlushEventArgs($this->em->reveal()));
     }
 

--- a/test/Provider/Entity/Gallery.php
+++ b/test/Provider/Entity/Gallery.php
@@ -59,9 +59,14 @@ class Gallery
 
     /**
      * @param string $name
+     * @return Visitor
      */
     public function addVisitor($name)
     {
-        $this->visitors->add(new Visitor($name));
+        $visitor = new Visitor($name);
+
+        $this->visitors->add($visitor);
+
+        return $visitor;
     }
 }

--- a/test/Provider/EntityMutationMetadataProviderTest.php
+++ b/test/Provider/EntityMutationMetadataProviderTest.php
@@ -61,6 +61,49 @@ class EntityMutationMetadataProviderTest extends \PHPUnit_Framework_TestCase
         self::assertCount(1, $this->provider->getFullChangeSet($this->em));
     }
 
+    public function testChangesNewEntity()
+    {
+        $gallery = new Gallery('foobar street 10');
+
+        $v1 = $gallery->addVisitor('henk');
+        $this->em->persist($gallery);
+
+        $v2 = $gallery->addVisitor('hans');
+
+        self::assertEquals([
+            Gallery::class => [$gallery],
+            Visitor::class => [$v2, $v1],
+        ], $this->provider->getFullChangeSet($this->em));
+    }
+
+    public function testChangesNewEntityFlushed()
+    {
+        $gallery = new Gallery('foobar street 10');
+
+        $v1 = $gallery->addVisitor('henk');
+        $this->em->persist($gallery);
+        $this->em->flush();
+
+        $v2 = $gallery->addVisitor('hans');
+
+        self::assertEquals([
+            Gallery::class => [$gallery],
+            Visitor::class => [$v1, $v2],
+        ], $this->provider->getFullChangeSet($this->em));
+    }
+
+    public function testChangesNewEntityOneToOne()
+    {
+        $root = new Node('root');
+        $root->mirror = $mirror = new Node('mirror');
+
+        $this->em->persist($root);
+
+        self::assertEquals([
+            Node::class => [$root, $mirror],
+        ], $this->provider->getFullChangeSet($this->em));
+    }
+
     public function testCreateOriginalEntity()
     {
         $tall_ship = new Painting('Tall Ship');


### PR DESCRIPTION
Events for new entities trigger at wrong times. This is because of the pre-persist listener.

This goes wrong when changing between persist and flush or when detaching the entity after a persist.