### PR TITLE
Fix/change merge

### DIFF
--- a/src/Provider/EntityMutationMetadataProvider.php
+++ b/src/Provider/EntityMutationMetadataProvider.php
@@ -195,7 +195,11 @@ class EntityMutationMetadataProvider
         foreach ($managed as $class => $entities) {
             $metadata = $em->getClassMetadata($class);
 
-            $change_set[$class] = array_values($entities);
+            if (isset($change_set[$class])) {
+                $change_set[$class] = array_merge($change_set[$class], array_values($entities));
+            } else {
+                $change_set[$class] = array_values($entities);
+            }
 
             foreach ($entities as $entity) {
                 $this->appendAssociations($em, $metadata, $entity, $change_set);

--- a/test/Provider/Entity/A.php
+++ b/test/Provider/Entity/A.php
@@ -1,0 +1,30 @@
+<?php
+namespace Hostnet\Component\EntityTracker\Provider\Entity;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ */
+class A
+{
+    /**
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
+     * @var int
+     */
+    public $id;
+
+    /**
+     * @ORM\OneToMany(targetEntity="B", mappedBy="a", cascade={"persist"})
+     * @var B[]|ArrayCollection
+     */
+    public $bees;
+
+    public function __construct()
+    {
+        $this->bees = new ArrayCollection();
+    }
+}

--- a/test/Provider/Entity/B.php
+++ b/test/Provider/Entity/B.php
@@ -1,0 +1,31 @@
+<?php
+namespace Hostnet\Component\EntityTracker\Provider\Entity;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity()
+ */
+class B
+{
+    /**
+     * @ORM\Id()
+     * @ORM\GeneratedValue()
+     * @ORM\Column(type="integer")
+     *
+     * @var int
+     */
+    private $id;
+
+    /**
+     * @ORM\ManyToOne(targetEntity="A", inversedBy="bees")
+     * @var Visitor
+     */
+    public $a;
+
+    public function __construct()
+    {
+    }
+
+}

--- a/test/Provider/Entity/Node.php
+++ b/test/Provider/Entity/Node.php
@@ -1,6 +1,7 @@
 <?php
 namespace Hostnet\Component\EntityTracker\Provider\Entity;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
@@ -53,5 +54,6 @@ class Node
     public function __construct($name)
     {
         $this->name = $name;
+        $this->children = new ArrayCollection();
     }
 }


### PR DESCRIPTION
In some cases where you have managed and new entities in associations the managed entities override the new ones. This caused the entities from not appearing in the change set.