### PR TITLE
Recursivly add elements to change set

### DIFF
--- a/src/Provider/EntityMutationMetadataProvider.php
+++ b/src/Provider/EntityMutationMetadataProvider.php
@@ -270,6 +270,10 @@ class EntityMutationMetadataProvider
                     continue;
                 }
 
+                if (!$assoc['isCascadePersist']) {
+                    continue;
+                }
+
                 $this->addToChangeSet($em, $target_class, $entry, $change_set);
             }
         }

--- a/test/Provider/Entity/C.php
+++ b/test/Provider/Entity/C.php
@@ -7,7 +7,7 @@ use Doctrine\ORM\Mapping as ORM;
 /**
  * @ORM\Entity()
  */
-class B
+class C
 {
     /**
      * @ORM\Id()
@@ -19,20 +19,13 @@ class B
     private $id;
 
     /**
-     * @ORM\ManyToOne(targetEntity="A", inversedBy="bees")
-     * @var A
+     * @ORM\ManyToOne(targetEntity="B", inversedBy="cees")
+     * @var C
      */
-    public $a;
-
-    /**
-     * @ORM\OneToMany(targetEntity="C", mappedBy="c", cascade={"persist"})
-     * @var c[]|ArrayCollection
-     */
-    public $cees;
+    public $b;
 
     public function __construct()
     {
-        $this->cees = new ArrayCollection();
     }
 
 }

--- a/test/Provider/EntityMutationMetadataProviderTest.php
+++ b/test/Provider/EntityMutationMetadataProviderTest.php
@@ -9,6 +9,7 @@ use Doctrine\ORM\Tools\Setup;
 use Hostnet\Component\DatabaseTest\MysqlPersistentConnection;
 use Hostnet\Component\EntityTracker\Provider\Entity\A;
 use Hostnet\Component\EntityTracker\Provider\Entity\B;
+use Hostnet\Component\EntityTracker\Provider\Entity\C;
 use Hostnet\Component\EntityTracker\Provider\Entity\Gallery;
 use Hostnet\Component\EntityTracker\Provider\Entity\Node;
 use Hostnet\Component\EntityTracker\Provider\Entity\Painting;
@@ -99,6 +100,7 @@ class EntityMutationMetadataProviderTest extends \PHPUnit_Framework_TestCase
         $a = new A();
         $b1 = new B();
         $b2 = new B();
+        $c = new C();
 
         $a->bees->add($b1);
         $b1->a = $a;
@@ -110,10 +112,14 @@ class EntityMutationMetadataProviderTest extends \PHPUnit_Framework_TestCase
         $a->bees->add($b2);
         $b2->a = $a;
 
+        $b2->cees->add($c);
+        $c->b = $b2;
+
         $change_set = $this->provider->getFullChangeSet($this->em);
 
         self::assertCount(1, $change_set[A::class]);
         self::assertCount(2, $change_set[B::class]);
+        self::assertCount(1, $change_set[C::class]);
     }
 
     public function testChangesNewEntityOneToOne()

--- a/test/Provider/EntityMutationMetadataProviderTest.php
+++ b/test/Provider/EntityMutationMetadataProviderTest.php
@@ -129,9 +129,7 @@ class EntityMutationMetadataProviderTest extends \PHPUnit_Framework_TestCase
 
         $this->em->persist($root);
 
-        self::assertEquals([
-            Node::class => [$root, $mirror],
-        ], $this->provider->getFullChangeSet($this->em));
+        self::assertEquals([Node::class => [$root]], $this->provider->getFullChangeSet($this->em));
     }
 
     public function testCreateOriginalEntity()


### PR DESCRIPTION
There are some cases that new entities are discovered more levels deep by "persistence through reachability". Doctrine solves this by calling persist on those and anything cascades with that. This behavior needs to be simulated.